### PR TITLE
Improve Shoulder Surfing Compatibility

### DIFF
--- a/src/main/java/net/p1nero/ss/compat/ShoulderSurfingCompat.java
+++ b/src/main/java/net/p1nero/ss/compat/ShoulderSurfingCompat.java
@@ -1,0 +1,39 @@
+package net.p1nero.ss.compat;
+
+import com.github.exopandora.shouldersurfing.api.callback.ICameraCouplingCallback;
+import com.github.exopandora.shouldersurfing.api.plugin.IShoulderSurfingPlugin;
+import com.github.exopandora.shouldersurfing.api.plugin.IShoulderSurfingRegistrar;
+import net.minecraft.client.Minecraft;
+import net.p1nero.ss.gameassets.SwordSoaringDatakeys;
+import net.p1nero.ss.skill.sword_soaring.SwordSoaringSkill;
+import org.jetbrains.annotations.NotNull;
+import yesman.epicfight.client.ClientEngine;
+import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
+import yesman.epicfight.world.capabilities.skill.PlayerSkills;
+
+@SuppressWarnings("unused") // Referenced in src/main/resources/shouldersurfing_plugin.json
+public class ShoulderSurfingCompat implements IShoulderSurfingPlugin {
+    @Override
+    public void register(IShoulderSurfingRegistrar registrar) {
+        registrar.registerCameraCouplingCallback(new ForceCameraCouplingWhileSwordSoaringFlying());
+    }
+
+    private static class ForceCameraCouplingWhileSwordSoaringFlying implements ICameraCouplingCallback {
+        @Override
+        public boolean isForcingCameraCoupling(Minecraft minecraft) {
+            final LocalPlayerPatch localPlayerPatch = ClientEngine.getInstance().getPlayerPatch();
+            if (localPlayerPatch == null) return false;
+
+            return isPlayerSwordSoaringFlying(localPlayerPatch);
+        }
+
+        private static boolean isPlayerSwordSoaringFlying(@NotNull LocalPlayerPatch localPlayerPatch) {
+            final PlayerSkills skills = localPlayerPatch.getPlayerSkills();
+            if (skills == null) return false;
+
+            return skills.listSkillContainers()
+                    .filter(container -> container != null && container.getSkill() instanceof SwordSoaringSkill)
+                    .anyMatch(container -> container.getDataManager().getDataValue(SwordSoaringDatakeys.FLYING));
+        }
+    }
+}

--- a/src/main/java/net/p1nero/ss/skill/sword_soaring/SwordSoaringSkill.java
+++ b/src/main/java/net/p1nero/ss/skill/sword_soaring/SwordSoaringSkill.java
@@ -1,6 +1,5 @@
 package net.p1nero.ss.skill.sword_soaring;
 
-import com.github.exopandora.shouldersurfing.api.client.ShoulderSurfing;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
@@ -13,7 +12,6 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
-import net.neoforged.fml.ModList;
 import net.neoforged.neoforge.client.event.MovementInputUpdateEvent;
 import net.neoforged.neoforge.event.entity.living.LivingEquipmentChangeEvent;
 import net.neoforged.neoforge.event.entity.living.LivingFallEvent;
@@ -30,7 +28,6 @@ import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.types.StaticAnimation;
 import yesman.epicfight.api.neoevent.playerpatch.SkillCastEvent;
 import yesman.epicfight.api.neoevent.playerpatch.TakeDamageEvent;
-import yesman.epicfight.api.utils.math.MathUtils;
 import yesman.epicfight.client.events.engine.ControlEngine;
 import yesman.epicfight.client.gui.BattleModeGui;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
@@ -187,12 +184,6 @@ public class SwordSoaringSkill extends Skill {
             if (container.getDataManager().getDataValue(SwordSoaringDatakeys.FLYING) && container.getExecutor().hasStamina(consumption + 0.1F) && SwordSoaringMod.isValidSword(container.getExecutor().getOriginal().getMainHandItem())) {
                 LocalPlayer localPlayer = ((LocalPlayer) container.getExecutor().getOriginal());
                 Vec3 view = localPlayer.getViewVector(1.0F).normalize();
-                if(ModList.get().isLoaded("shouldersurfing")) {
-                    view = MathUtils.getVectorForRotation(ShoulderSurfing.getInstance().getCamera().getXRot(), ShoulderSurfing.getInstance().getCamera().getYRot());
-                    container.getExecutor().getOriginal().setYRot((float) MathUtils.getYRotOfVector(view));
-                    container.getExecutor().getOriginal().setYHeadRot((float) MathUtils.getYRotOfVector(view));
-                    container.getExecutor().getOriginal().setXRot((float) MathUtils.getXRotOfVector(view));
-                }
                 Vec3 accelerationSpeed = view.scale(speed);
 
                 Vec3 normalSpeed = accelerationSpeed.scale(0.33F);

--- a/src/main/resources/shouldersurfing_plugin.json
+++ b/src/main/resources/shouldersurfing_plugin.json
@@ -1,0 +1,3 @@
+{
+  "entrypoint": "net.p1nero.ss.compat.ShoulderSurfingCompat"
+}


### PR DESCRIPTION
### Details

This reverts the changes made in [this commit](https://github.com/GaylordFockerCN/SwordSoaring-Reborn/commit/ad069d0323558bfa21b882256a229c67940084fb), which add support for Shoulder Surfing but it does not use the [built-in supported force camera coupling API](https://github.com/Exopandora/ShoulderSurfing/wiki/API-Documentation-Callbacks#icameracouplingcallback) provided by Shoulder Surfing Reloaded mod, it manually updates the camera which can be less smooth.

Instead, this solution [registers a Shoulder Surfing plugin](https://github.com/Exopandora/ShoulderSurfing/wiki/API-Documentation-Plugins), which is loaded only when the mod installed and adds a callback to force camera coupling when flying using sword soaring. This also aligns with the [Epic Fight PR #2112](https://github.com/Epic-Fight/epicfight/pull/2112) for adding Shoulder Surfing compatibility.

---

### Videos

<details><summary>Before</summary>
<p>

https://github.com/user-attachments/assets/f0d99271-6e24-4c39-a0be-e8e060c635f4

</p>
</details> 

<details><summary>After</summary>
<p>

https://github.com/user-attachments/assets/06e6edb1-e5eb-4ca7-a055-bd275f5d1d12

</p>
</details> 